### PR TITLE
Fix Ant web.dir property casing

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -10,7 +10,7 @@
     <property name="deprecation" value="off" />
     <property name="optimize" value="off" />
 
-	<property name="web.dir" value="webcontent"/>
+	<property name="web.dir" value="WebContent"/>
     <property name="src.dir" value="src" />
    	<property name="dist.dir" value="dist"/>
 	<property name="baseofdist.dir" value="coverage"/>


### PR DESCRIPTION
The `ant compile` command fails on Debian 10 due to the web.dir property casing.
```
$ ant compile
Buildfile: /home/admin/CoverageWebApplication/build.xml

init:

compile:
    [mkdir] Created dir: /home/admin/CoverageWebApplication/webcontent/WEB-INF/classes
     [echo]  Compiling coverage source in src into webcontent/WEB-INF/classes
    [javac] /home/admin/CoverageWebApplication/build.xml:62: warning: 'includeantruntime' was not set, defaulting to build.sysclasspath=last; set to false for repeatable builds
    [javac] Compiling 37 source files to /home/admin/CoverageWebApplication/webcontent/WEB-INF/classes

BUILD FAILED
/home/admin/CoverageWebApplication/build.xml:62: /home/admin/CoverageWebApplication/webcontent/WEB-INF/lib does not exist.

Total time: 0 seconds
```